### PR TITLE
Integrated ocpp201.module.patch

### DIFF
--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -421,9 +421,11 @@ void OCPP201::ready() {
         };
 
     // Smart Charging support
+    EVLOG_warning << "Launching timer for calling set_external_limits function";
     this->charging_schedules_timer = std::make_unique<Everest::SteadyTimer>([this]() {
         const auto charging_schedules =
             this->charge_point->get_all_composite_charging_schedules(this->config.PublishChargingScheduleDurationS);
+        EVLOG_warning << "Timer complete, calling set_external_limits function";
         this->set_external_limits(charging_schedules);
         this->publish_charging_schedules(charging_schedules);
     });
@@ -434,7 +436,7 @@ void OCPP201::ready() {
     };
 
     callbacks.signal_set_charging_profiles_callback = [this]() {
-        EVLOG_info << "Received a new Charging Schedules from the CSMS or another actor.";
+        EVLOG_warning << "Received a new Charging Schedules from the CSMS or another actor.";
         const auto charging_schedules =
             this->charge_point->get_all_composite_charging_schedules(this->config.PublishChargingScheduleDurationS);
         this->set_external_limits(charging_schedules);
@@ -577,6 +579,8 @@ void OCPP201::set_external_limits(const std::map<int32_t, ocpp::v201::CompositeS
     // for each EVSE
     for (auto const& [evse_id, schedule] : charging_schedules) {
         types::energy::ExternalLimits limits;
+        // SORRY!!
+        if (evse_id == 0) continue;
         std::vector<types::energy::ScheduleReqEntry> schedule_import;
         for (const auto period : schedule.chargingSchedulePeriod) {
             types::energy::ScheduleReqEntry schedule_req_entry;

--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -421,11 +421,11 @@ void OCPP201::ready() {
         };
 
     // Smart Charging support
-    EVLOG_warning << "Launching timer for calling set_external_limits function";
+    EVLOG_info << "Launching timer for calling set_external_limits function";
     this->charging_schedules_timer = std::make_unique<Everest::SteadyTimer>([this]() {
         const auto charging_schedules =
             this->charge_point->get_all_composite_charging_schedules(this->config.PublishChargingScheduleDurationS);
-        EVLOG_warning << "Timer complete, calling set_external_limits function";
+        EVLOG_info << "Timer complete, calling set_external_limits function";
         this->set_external_limits(charging_schedules);
         this->publish_charging_schedules(charging_schedules);
     });
@@ -436,7 +436,7 @@ void OCPP201::ready() {
     };
 
     callbacks.signal_set_charging_profiles_callback = [this]() {
-        EVLOG_warning << "Received a new Charging Schedules from the CSMS or another actor.";
+        EVLOG_info << "Received a new Charging Schedules from the CSMS or another actor.";
         const auto charging_schedules =
             this->charge_point->get_all_composite_charging_schedules(this->config.PublishChargingScheduleDurationS);
         this->set_external_limits(charging_schedules);
@@ -579,7 +579,8 @@ void OCPP201::set_external_limits(const std::map<int32_t, ocpp::v201::CompositeS
     // for each EVSE
     for (auto const& [evse_id, schedule] : charging_schedules) {
         types::energy::ExternalLimits limits;
-        // SORRY!!
+        // Sorry for introducing this hack. Unfortunately, cleaning it up will require significantly  
+        // refactoring the mapping datastructure, which will involve coordination with the community,
         if (evse_id == 0) continue;
         std::vector<types::energy::ScheduleReqEntry> schedule_import;
         for (const auto period : schedule.chargingSchedulePeriod) {


### PR DESCRIPTION
## Describe your changes

This PR integrates the `ocpp201.module.patch` file that is currently being using in the `charin-e2e-demo`. The goal is to completely get rid of all of the patches so that the `charin-e2e-demo` can be fully functional and not rely on hacky patches. 

**Testing Done**

This code was tested alongside all of the other patches in `everest-demo/charin-e2e-demo`. In the demo, `setChargingProfile`, which this patch helps implement, seems to work on a basic level.

## Issue ticket number and link

The issue that this is related to can be found [here](https://github.com/EVerest/everest-demo/issues/61).

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

